### PR TITLE
Travis build for backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+branches:
+  only:
+    - master
+python: 
+    - "3.6"
+
+install:
+    - pip install -r requirements.txt
+script:
+    - pytest
+services:
+  - sqlite  
+env:
+  - DJANGO=2.2.6


### PR DESCRIPTION
Added .travis.yml to the root directory 
When a build is triggered, it should install the requirements listed in requirements.txt and run pytest
I can't get Travis-CI to recognize the .yml on this branch

If anyone has prior experience with CI/CD, does the .yml have to be on master for Travis-CI to work?
Adding everyone from midtier as reviewers to help get this figured out